### PR TITLE
mojxml-rs 方式の変換パイプラインを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,14 @@ RUN git clone https://github.com/felt/tippecanoe.git && \
 # for mojxml2geojson
 RUN pip install --break-system-packages git+https://github.com/digital-go-jp/mojxml2geojson.git
 
+# for mojxml-rs (Rust frontend, mojxml2geojson と並行して検証するため Release binary を導入)
+ARG MOJXML_RS_VERSION=v0.3.0
+RUN wget https://github.com/KotobaMedia/mojxml-rs/releases/download/${MOJXML_RS_VERSION}/mojxml-rs-x86_64-unknown-linux-gnu.zip \
+    && unzip mojxml-rs-x86_64-unknown-linux-gnu.zip \
+    && mv mojxml-rs /usr/local/bin/ \
+    && chmod +x /usr/local/bin/mojxml-rs \
+    && rm mojxml-rs-x86_64-unknown-linux-gnu.zip
+
 # for go-pmtiles
 RUN wget https://github.com/protomaps/go-pmtiles/releases/download/v1.26.1/go-pmtiles_1.26.1_Linux_x86_64.tar.gz \
     && tar xvf go-pmtiles_1.26.1_Linux_x86_64.tar.gz \

--- a/Rakefile
+++ b/Rakefile
@@ -5,34 +5,61 @@ def pref_range
   (start_pref..end_pref).map { |i| sprintf('%02d', i) }
 end
 
+# tippecanoe / tile-join コマンド（既存方式と mojxml-rs 方式で共用する）
+def daihyo_tippecanoe(pref)
+  'tippecanoe --quiet --drop-densest-as-needed ' \
+  '-x 筆ID -x version -x 代表点緯度 -x 代表点経度 ' \
+  '--minimum-zoom=2 --maximum-zoom=11 ' \
+  "-f -o output/#{pref}-daihyo.mbtiles"
+end
+
+def fude_tippecanoe(pref)
+  'tippecanoe --quiet ' \
+  '-x version -x 代表点緯度 -x 代表点経度 ' \
+  '--minimum-zoom=12 --maximum-zoom=16 --no-tile-size-limit ' \
+  "-f -o output/#{pref}-fude.mbtiles"
+end
+
+def join_layers(pref)
+  'tile-join --no-tile-size-limit ' \
+  "-f -o output/#{pref}.mbtiles " \
+  "output/#{pref}-fude.mbtiles output/#{pref}-daihyo.mbtiles"
+end
+
 desc 'create mbtiles'
 task :mbtiles do
   pref_range.each do |pref|
     next if File.exist?("#{pref}.mbtiles")
     $stderr.print "#{Time.now}: #{pref}\n"
     sh <<-EOS
-TYPE=daihyo PREF=#{pref} ruby stream.rb | \
-tippecanoe \
---quiet \
---drop-densest-as-needed \
--x 筆ID \
--x version \
--x 代表点緯度 \
--x 代表点経度 \
---minimum-zoom=2 \
---maximum-zoom=11 \
--f -o output/#{pref}-daihyo.mbtiles; \
-TYPE=fude PREF=#{pref} ruby stream.rb | \
-tippecanoe \
---quiet \
--x version \
--x 代表点緯度 \
--x 代表点経度 \
---minimum-zoom=12 \
---maximum-zoom=16 \
---no-tile-size-limit \
--f -o output/#{pref}-fude.mbtiles; \
-tile-join --no-tile-size-limit -f -o output/#{pref}.mbtiles output/#{pref}-fude.mbtiles output/#{pref}-daihyo.mbtiles;
+TYPE=daihyo PREF=#{pref} ruby stream.rb | #{daihyo_tippecanoe(pref)}; \
+TYPE=fude PREF=#{pref} ruby stream.rb | #{fude_tippecanoe(pref)}; \
+#{join_layers(pref)};
+    EOS
+  end
+end
+
+desc 'create mbtiles using mojxml-rs (Rust frontend)'
+task :mbtiles_rs do
+  pref_range.each do |pref|
+    next if File.exist?("output/#{pref}.mbtiles")
+    zips = Dir.glob("src/**/#{pref}*-*-*.zip").sort
+    if zips.empty?
+      $stderr.print "#{Time.now}: #{pref} skip (no zip)\n"
+      next
+    end
+    $stderr.print "#{Time.now}: #{pref} (#{zips.size} zip)\n"
+
+    raw = "output/#{pref}.raw.geojson"
+    # mojxml-rs は zip 群を一括・並列変換し newline-delimited GeoJSON を出力する。
+    # 任意座標系・地区外・別図はデフォルトで除外されるため grep -v 任意座標 は不要。
+    sh "mojxml-rs #{raw} #{zips.join(' ')}"
+
+    # 1 度の変換結果（raw）から fude / daihyo を生成し、XML の二重パースを避ける。
+    sh <<-EOS
+cat #{raw} | PREF=#{pref} ruby daihyo_from_mojxml_rs.rb | #{daihyo_tippecanoe(pref)}; \
+cat #{raw} | PREF=#{pref} ruby fude_from_mojxml_rs.rb | #{fude_tippecanoe(pref)}; \
+#{join_layers(pref)};
     EOS
   end
 end

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,37 @@
+# Third Party Notices
+
+本リポジトリが生成・配布するコンテナには、以下のサードパーティソフトウェアが含まれる。
+各ソフトウェアはそれぞれのライセンスのもとで提供される。
+
+## mojxml-rs
+
+- Repository: https://github.com/KotobaMedia/mojxml-rs
+- License: MIT License
+- Copyright (c) 2026 KotobaMedia, Inc.
+
+```
+MIT License
+
+Copyright (c) 2026 KotobaMedia, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+mojxml-rs が依存する Rust crate のライセンスは、必要に応じて `cargo-about` または
+`cargo-deny` で確認する。

--- a/daihyo_from_mojxml_rs.rb
+++ b/daihyo_from_mojxml_rs.rb
@@ -1,0 +1,27 @@
+require 'json'
+
+# mojxml-rs（Rust 実装）が出力する newline-delimited GeoJSON を受け取り、
+# 既存 daihyo.rb と同等の daihyo レイヤー（代表点ポイント）NDJSON に変換する。
+# 代表点経度 / 代表点緯度 から Point Feature を生成する方針は既存と同じ。
+
+while gets
+  f = JSON.parse($_)
+  props = f['properties'] || {}
+  pt = {
+    :type => 'Feature',
+    :tippecanoe => {
+      :layer => 'daihyo',
+      :minzoom => 2,
+      :maxzoom => 11
+    },
+    :properties => {},
+    :geometry => {
+      :type => 'Point',
+      :coordinates => [
+        props['代表点経度'],
+        props['代表点緯度']
+      ]
+    }
+  }
+  print "\x1e#{JSON.dump(pt)}\n"
+end

--- a/docs/mojxml-rs.md
+++ b/docs/mojxml-rs.md
@@ -1,0 +1,76 @@
+# mojxml-rs 導入による前段処理の Rust 化（検証用メモ）
+
+地図XML → GeoJSON/NDJSON 変換の前段を [`KotobaMedia/mojxml-rs`](https://github.com/KotobaMedia/mojxml-rs)
+（Rust 実装・MIT License）へ置き換える検証のための構成。既存方式（`mojxml2geojson` + `fude.rb` / `daihyo.rb`）は
+そのまま残し、いつでも切り替え・比較できるようにしている。
+
+## 構成
+
+| 役割 | 既存方式 | mojxml-rs 方式 |
+| --- | --- | --- |
+| XML → GeoJSON | `mojxml2geojson`（Python, zip ごと） | `mojxml-rs`（Rust, zip 群を一括・並列） |
+| fude 後処理 | `fude.rb` | `fude_from_mojxml_rs.rb` |
+| daihyo 後処理 | `daihyo.rb` | `daihyo_from_mojxml_rs.rb` |
+| Rake task | `rake mbtiles` | `rake mbtiles_rs` |
+
+`rake pmtiles` / `rake style` は両方式で共通（成果物は `output/{pref}.mbtiles` に揃える）。
+
+## mojxml-rs 方式の流れ
+
+```text
+mojxml-rs で pref 単位の raw NDJSON を作成（output/{pref}.raw.geojson）
+→ raw から daihyo レイヤー生成（daihyo_from_mojxml_rs.rb）
+→ raw から fude レイヤー生成（fude_from_mojxml_rs.rb）
+→ tippecanoe
+→ tile-join → output/{pref}.mbtiles
+```
+
+XML パースは pref あたり 1 回のみ。既存方式は daihyo / fude で `stream.rb` を 2 回走らせ、XML を
+二重パースしていたが、その重複を解消している。
+
+## 出力フォーマットの差分（mojxml2geojson との比較）
+
+- `mojxml-rs` は newline-delimited GeoJSON を出力する（`tippecanoe-json-tool` での分割は不要）。
+- 任意座標系・地区外・別図はデフォルトで除外される（`grep -v 任意座標` 相当）。
+  含める場合は `-a` / `-A` / `-c` オプションを使う。
+- 筆IDの属性名が `筆id`（小文字）。`version` 属性は出力されない。
+  - `fude_from_mojxml_rs.rb` で `筆id` を `筆ID` へ正規化し、既存成果物と属性名を揃える。
+- `代表点緯度` / `代表点経度` は出力されるため、daihyo の代表点生成は既存と同じ方針で行える。
+- `global_id` は `{pref}_{市区町村コード}_{筆ID}` から決定的に生成する。
+  `mojxml-rs` は zip を一括変換しファイル名（連番）を持たないため、既存の `{pref}_{basename}_{筆ID}` とは
+  ID 値が変わる点に注意（pref 内での一意性・決定性は保たれる）。
+
+## 1 zip での差分確認（Step 2）
+
+```bash
+# 既存方式
+TYPE=fude   PREF=01 ruby to_geojson.rb src/path/to/01101-4300-1.zip > old-fude.ndjson
+TYPE=daihyo PREF=01 ruby to_geojson.rb src/path/to/01101-4300-1.zip > old-daihyo.ndjson
+
+# mojxml-rs 方式
+mojxml-rs output/01.raw.geojson src/path/to/01101-4300-1.zip
+cat output/01.raw.geojson | PREF=01 ruby fude_from_mojxml_rs.rb   > new-fude.ndjson
+cat output/01.raw.geojson | PREF=01 ruby daihyo_from_mojxml_rs.rb > new-daihyo.ndjson
+
+# 件数・属性差分の確認例
+wc -l old-fude.ndjson new-fude.ndjson
+```
+
+## ベンチマーク（Step 5）
+
+```bash
+START_PREF=1 END_PREF=1 /usr/bin/time -v rake mbtiles
+START_PREF=1 END_PREF=1 /usr/bin/time -v rake mbtiles_rs
+/usr/bin/time -v rake pmtiles
+```
+
+比較対象：1 zip / 1 市区町村 / 北海道全体（pref=01）で、既存方式と mojxml-rs 方式の処理時間・メモリ使用量・
+成果物（件数・属性・ID・見た目）を確認する。
+
+> 大規模データで `/tmp` の容量が足りない場合は `mojxml-rs -t <dir> ...` で展開先を指定する。
+
+## 切り替え
+
+- 既存方式に戻す場合は `rake mbtiles` を使う。
+- どちらも `output/{pref}.mbtiles` を生成するため、比較する際は出力先を分けるか、片方ずつ実行する。
+- `mojxml-rs` バイナリのバージョンは Dockerfile の `MOJXML_RS_VERSION`（既定 `v0.3.0`）で固定している。

--- a/fude_from_mojxml_rs.rb
+++ b/fude_from_mojxml_rs.rb
@@ -1,0 +1,46 @@
+require 'json'
+require 'digest'
+
+# mojxml-rs（Rust 実装）が出力する newline-delimited GeoJSON を受け取り、
+# 既存 fude.rb と同等の fude レイヤー（ポリゴン）NDJSON に変換する。
+# 既存方式（mojxml2geojson + fude.rb）と並行して検証できるよう別スクリプトにしている。
+#
+# mojxml2geojson との主な差分
+# - 筆ID の属性名が mojxml-rs では「筆id」（小文字）になる
+# - version 属性は出力されない
+# - 任意座標系・地区外・別図はデフォルトで出力されない（grep -v 任意座標 が不要）
+# 既存成果物と属性名をそろえるため、出力時に「筆id」を「筆ID」へ正規化する。
+
+pref = ENV['PREF']
+
+# SHA256由来のハッシュ値を、53bit符号なし整数（JavaScriptで安全に扱える範囲）に縮小する。
+# 詳細な意図は fude.rb の同名関数を参照。
+MAX_SAFE_INTEGER = (1 << 53) - 1  # => 9_007_199_254_740_991
+def safe_id(str)
+  Digest::SHA256.hexdigest(str)[0, 16].to_i(16) % MAX_SAFE_INTEGER
+end
+
+while gets
+  f = JSON.parse($_)
+  props = f['properties']
+  if props
+    # mojxml-rs は「筆id」、mojxml2geojson は「筆ID」。両対応とし「筆ID」へ寄せる。
+    fude_id = props['筆ID'] || props['筆id']
+    if fude_id
+      props.delete('筆id')
+      props['筆ID'] = fude_id
+
+      # mojxml-rs は zip 群を一括変換するためファイル名（連番）を属性に持たない。
+      # global_id は pref・市区町村コード・筆ID から決定的に生成し、pref 内で一意にする。
+      uid_str = "#{pref}_#{props['市区町村コード']}_#{fude_id}"
+      props['global_id'] = uid_str
+      f['id'] = safe_id(uid_str)
+    end
+  end
+  f[:tippecanoe] = {
+    :layer => 'fude',
+    :minzoom => 12,
+    :maxzoom => 16
+  }
+  print "\x1e#{JSON.dump(f)}\n"
+end


### PR DESCRIPTION
## 概要

地図XML変換の前段を Rust 実装の `mojxml-rs` に置き換える検証用の構成を、既存方式と並行して利用できる形で追加する。既存方式（`mojxml2geojson` + `fude.rb` / `daihyo.rb`）はそのまま残し、いつでも切り替え・比較できる。

## 変更点

- Dockerfile に `mojxml-rs` の Release binary 導入を追加（`MOJXML_RS_VERSION` で固定、既定 `v0.3.0`）
- `fude_from_mojxml_rs.rb` / `daihyo_from_mojxml_rs.rb` を追加
  - `mojxml-rs` の newline-delimited GeoJSON を既存 fude / daihyo レイヤーへ変換
  - `筆id` を `筆ID` へ正規化し、`global_id` を `市区町村コード + 筆ID` から決定的に生成
- Rakefile に `mbtiles_rs` task を追加し、tippecanoe / tile-join コマンドを既存 `mbtiles` と共用
  - pref 単位で `mojxml-rs` を 1 回実行し、raw から fude / daihyo を生成して XML の二重パースを解消
- `THIRD_PARTY_NOTICES.md` に `mojxml-rs` の MIT License 表記を追加
- `docs/mojxml-rs.md` に構成・差分・比較手順・ベンチマーク手順を記載

## mojxml-rs 出力スキーマの確認結果

- `筆ID` の属性名は `筆id`（小文字）。`version` 属性は出力されない
- 任意座標系・地区外・別図はデフォルトで除外される（`grep -v 任意座標` 相当が不要）
- `代表点緯度` / `代表点経度` は出力されるため daihyo は既存方針のまま生成可能
- `global_id` は連番（basename）を持たないため `{pref}_{市区町村コード}_{筆ID}` で決定的に生成（既存とは ID 値が変わる）

## 未実施（検証用メモは docs/mojxml-rs.md に記載）

- 実データでの 1 zip 差分確認（Step 2）
- 北海道全体での処理時間・メモリ使用量のベンチマーク（Step 5）

Closes #9