### PR TITLE
mbtiles_rs に FGB 連携用の中間 NDJSON 書き出しを追加

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -56,9 +56,11 @@ task :mbtiles_rs do
     sh "mojxml-rs #{raw} #{zips.join(' ')}"
 
     # 1 度の変換結果（raw）から fude / daihyo を生成し、XML の二重パースを避ける。
+    # fude は tippecanoe へ流しつつ、NDJSON_OUT に市区町村コード単位の中間 NDJSON を
+    # 書き出して FGB 生成パイプライン（geo-ditto-fgb）へ連携する。
     sh <<-EOS
 cat #{raw} | PREF=#{pref} ruby daihyo_from_mojxml_rs.rb | #{daihyo_tippecanoe(pref)}; \
-cat #{raw} | PREF=#{pref} ruby fude_from_mojxml_rs.rb | #{fude_tippecanoe(pref)}; \
+cat #{raw} | PREF=#{pref} NDJSON_OUT=tmp ruby fude_from_mojxml_rs.rb | #{fude_tippecanoe(pref)}; \
 #{join_layers(pref)};
     EOS
   end

--- a/docs/mojxml-rs.md
+++ b/docs/mojxml-rs.md
@@ -28,6 +28,26 @@ mojxml-rs で pref 単位の raw NDJSON を作成（output/{pref}.raw.geojson）
 XML パースは pref あたり 1 回のみ。既存方式は daihyo / fude で `stream.rb` を 2 回走らせ、XML を
 二重パースしていたが、その重複を解消している。
 
+## FGB 生成パイプライン（geo-ditto-fgb）との連携
+
+表示用の PMTiles とは別に、地物選択→エクスポートのために
+[`geo-ditto-fgb`](https://github.com/shinyanakashima/geo-ditto-fgb) が FlatGeobuf を生成する。
+PMTiles と FGB は**同一の `global_id` で突合**するため、両者は同じ NDJSON 由来である必要がある。
+
+`mbtiles_rs` では `fude_from_mojxml_rs.rb` に `NDJSON_OUT=tmp` を渡し、tippecanoe へ流すのと
+同じ NDJSON を、市区町村コード単位で次の場所に保存する。
+
+```text
+tmp/{pref}/{市区町村コード}/{市区町村コード}.ndjson
+```
+
+`geo-ditto-fgb` はこの階層を走査して市区町村コード単位の FGB を作り、`merged.fgb` に統合する。
+
+- `global_id` を持つ地物のみ書き出す（マッチング不能な地物は除外）。
+- 市区町村コード単位に分割するのは、FGB 1 ファイルあたりのサイズ・メモリを抑えるため。
+- 可視化アプリは `merged.fgb` を読み、`global_id` で PMTiles の選択地物と突合する。
+  そのため FGB の個別ファイル名は内部的な詳細で、アプリには影響しない。
+
 ## 出力フォーマットの差分（mojxml2geojson との比較）
 
 - `mojxml-rs` は newline-delimited GeoJSON を出力する（`tippecanoe-json-tool` での分割は不要）。

--- a/fude_from_mojxml_rs.rb
+++ b/fude_from_mojxml_rs.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'digest'
+require 'fileutils'
 
 # mojxml-rs（Rust 実装）が出力する newline-delimited GeoJSON を受け取り、
 # 既存 fude.rb と同等の fude レイヤー（ポリゴン）NDJSON に変換する。
@@ -10,8 +11,15 @@ require 'digest'
 # - version 属性は出力されない
 # - 任意座標系・地区外・別図はデフォルトで出力されない（grep -v 任意座標 が不要）
 # 既存成果物と属性名をそろえるため、出力時に「筆id」を「筆ID」へ正規化する。
+#
+# NDJSON_OUT が設定されている場合は、tippecanoe へ流す stdout に加えて、
+# FGB 生成パイプライン（geo-ditto-fgb）が読む中間 NDJSON を
+# {NDJSON_OUT}/{pref}/{市区町村コード}/{市区町村コード}.ndjson に書き出す。
+# PMTiles と FGB は同一の NDJSON（同一 global_id）由来となり、
+# 地物選択→エクスポート時の global_id マッチングが保証される。
 
 pref = ENV['PREF']
+ndjson_out = ENV['NDJSON_OUT']
 
 # SHA256由来のハッシュ値を、53bit符号なし整数（JavaScriptで安全に扱える範囲）に縮小する。
 # 詳細な意図は fude.rb の同名関数を参照。
@@ -20,27 +28,50 @@ def safe_id(str)
   Digest::SHA256.hexdigest(str)[0, 16].to_i(16) % MAX_SAFE_INTEGER
 end
 
-while gets
-  f = JSON.parse($_)
-  props = f['properties']
-  if props
-    # mojxml-rs は「筆id」、mojxml2geojson は「筆ID」。両対応とし「筆ID」へ寄せる。
-    fude_id = props['筆ID'] || props['筆id']
-    if fude_id
-      props.delete('筆id')
-      props['筆ID'] = fude_id
+# 市区町村コード単位の出力ファイルを開いて使い回す（FGB のファイルサイズ・メモリ対策）
+writers = {}
+def writer_for(writers, ndjson_out, pref, city)
+  writers[city] ||= begin
+    dir = File.join(ndjson_out, pref.to_s, city.to_s)
+    FileUtils.mkdir_p(dir)
+    File.open(File.join(dir, "#{city}.ndjson"), 'w')
+  end
+end
 
-      # mojxml-rs は zip 群を一括変換するためファイル名（連番）を属性に持たない。
-      # global_id は pref・市区町村コード・筆ID から決定的に生成し、pref 内で一意にする。
-      uid_str = "#{pref}_#{props['市区町村コード']}_#{fude_id}"
-      props['global_id'] = uid_str
-      f['id'] = safe_id(uid_str)
+begin
+  while gets
+    f = JSON.parse($_)
+    props = f['properties']
+    fude_id = nil
+    city = nil
+    if props
+      # mojxml-rs は「筆id」、mojxml2geojson は「筆ID」。両対応とし「筆ID」へ寄せる。
+      fude_id = props['筆ID'] || props['筆id']
+      city = props['市区町村コード']
+      if fude_id
+        props.delete('筆id')
+        props['筆ID'] = fude_id
+
+        # mojxml-rs は zip 群を一括変換するためファイル名（連番）を属性に持たない。
+        # global_id は pref・市区町村コード・筆ID から決定的に生成し、pref 内で一意にする。
+        uid_str = "#{pref}_#{city}_#{fude_id}"
+        props['global_id'] = uid_str
+        f['id'] = safe_id(uid_str)
+      end
+    end
+    f[:tippecanoe] = {
+      :layer => 'fude',
+      :minzoom => 12,
+      :maxzoom => 16
+    }
+    line = "\x1e#{JSON.dump(f)}\n"
+    print line
+
+    # global_id を持つ地物のみ FGB 用 NDJSON に残す（マッチング不能な地物は除外）
+    if ndjson_out && fude_id && city
+      writer_for(writers, ndjson_out, pref, city).print line
     end
   end
-  f[:tippecanoe] = {
-    :layer => 'fude',
-    :minzoom => 12,
-    :maxzoom => 16
-  }
-  print "\x1e#{JSON.dump(f)}\n"
+ensure
+  writers.each_value(&:close)
 end


### PR DESCRIPTION
## 概要

`rake mbtiles_rs`（mojxml-rs 経路）が中間 NDJSON を保存せず tippecanoe へ直結していたため、FGB 生成パイプライン（`geo-ditto-fgb`）の入力が得られなかった。fude の後処理出力を市区町村コード単位の NDJSON として永続化し、PMTiles と FGB を同一 NDJSON（同一 `global_id`）由来にする。

## 背景

可視化アプリは PMTiles で選択した地物の `global_id` を、`merged.fgb` 内の同一 `global_id` 地物と突合し、簡略化されていない正確なジオメトリをエクスポートする。よって PMTiles と FGB は同じ `global_id` を共有している必要がある（#11）。

## 変更点

- `fude_from_mojxml_rs.rb`: `NDJSON_OUT` 指定時、tippecanoe へ流す stdout に加えて `tmp/{pref}/{市区町村コード}/{市区町村コード}.ndjson` を書き出す
  - `global_id` を持つ地物のみ出力（マッチング不能な地物は除外）
  - 市区町村コード単位に分割し、FGB 1 ファイルあたりのサイズ・メモリを抑える
  - `NDJSON_OUT` 未指定時は従来どおり stdout のみ（差分確認用途は不変）
- `Rakefile`: `mbtiles_rs` の fude 生成に `NDJSON_OUT=tmp` を付与
- `docs/mojxml-rs.md`: `geo-ditto-fgb` との連携を追記

## 互換性の確認

- 可視化アプリ（Mabiki 2.1）は単一の `merged.fgb` を読み、`global_id` で突合しているため、市区町村コード単位のファイル名変更や `global_id` 採番方式の変更による影響はない。
- 突合キーが `global_id`（文字列）であることはアプリ側の実装で確認済み。
- 年次で作り直すため、前年度との ID 継続性は不要。

## 未実施

- 実データでの動作確認（mojxml-rs / tippecanoe / geo-ditto-fgb を通した end-to-end）

## 関連

- #11（NDJSON を単一中間成果物とした再設計）
- #9, #10（mojxml-rs 並行経路の追加）